### PR TITLE
Fix: One too many zeroes in Argon Gas capacity of Kontainer Tank (3.75m)

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_03.cfg
@@ -55,7 +55,7 @@ bulkheadProfiles = size3,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 65000;650000;65000000;5850,7150;65000;65000;65000;260000;13000;13000
+		resourceAmounts = 65000;650000;6500000;5850,7150;65000;65000;65000;260000;13000;13000
 		initialResourceAmounts = 0;0;0;0;0;0;0;0;0;0
 		tankCost = 259999994;2600000;682500;5967;52;1040000;0;9554.5;10400;15600
 		basePartMass = 8.125


### PR DESCRIPTION
Normally, it seems Kontainers that can carry gases (Kontainer Tanks, Spheres) should have the capacity to carry 10 times as many units of Argon as Xenon. The Kontainer Tank (3.75m) [Tank_03.cfg] however has 100 times the Argon capacity as Xenon -- I suspect a typographical error.

I've reduced the capacity to be in-line with all the other Kontainer types.