### PR TITLE
Add ModuleCryoTank to liquid kontainers that lacked it

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/CryoTanks.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/CryoTanks.cfg
@@ -1,4 +1,4 @@
-@PART[C3_Tank_*,C3_RTank_*,RadialLqdTank,MountableLqdTank]:NEEDS[SimpleBoiloff]
+@PART[C3_Tank_*,C3_RTank_*,C3_FlatRnd_*,C3_LqdTrussTank,RadialLqdTank,MountableLqdTank]:NEEDS[SimpleBoiloff]
 {
     MODULE
 	{


### PR DESCRIPTION
When CryoTanks is installed, all tanks that can hold `LqdHydrogen` should have a `ModuleCryoTank` that makes the hydrogen boil off unless the tank is actively cooled.  The CryoTanks mod automatically patches all tanks that don't already have fuel switchers, but it doesn't touch the USI tanks because they have `FSfuelSwitch` modules.  The `CryoTanks.cfg` file here is what adds boiloff to the USI tanks, but a few tanks had been omitted.  I've added them to the patch so that everything gets LH2 boiloff as it should.