### PR TITLE
Increase cryo tank CoolingCost to the value for non-ZBO tanks

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/CryoTanks.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/CryoTanks.cfg
@@ -3,7 +3,7 @@
     MODULE
 	{
 		name =  ModuleCryoTank
-		CoolingCost = 0.08
+		CoolingCost = 0.09
 		CoolingEnabled = False
 		BOILOFFCONFIG
 		{


### PR DESCRIPTION
This isn't a bugfix, just a suggestion.  @ChrisAdderley (Nertea) might want to weigh in on this.

Kontainer tanks support cryo cooling (to prevent LH2 boiloff) at the cost of 0.08 EC/sec per cubic meter, the same as the CryoTanks mod's special-purpose insulated zero-boiloff (ZBO) tanks.  This patch was added at a time when that cost was the standard to follow: LH2 tanks could either be cooled for 0.08 EC/sec/m^3, or not at all.

Later, CryoTanks adopted the convention that non-ZBO tanks (such as stock ones) could also do cryo cooling, but at the slightly-higher cost of 0.09 EC/sec/m^3. That's a 12.5% penalty, meant to reflect that general-purpose fuel tanks don't have the extra insulation that a special-purpose ZBO tank has.

Since USI kontainer tanks are about as general-purpose as any fuel tank can be, it seems appropriate for them to use the higher cooling cost meant for most tanks, rather than the lower cost for special ZBO tanks.