### PR TITLE
Community Category Kit support for the KIS Kontainers

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainers_CCK.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Kontainers_CCK.cfg
@@ -1,0 +1,7 @@
+// Add the appropriate CCK tag to all USI KIS Kontainers
+// made by LEGIONBOSS
+
+@PART[C3_Kontainer_KIS_*]:NEEDS[CommunityCategoryKit]
+{
+	tags = cck-containers
+}


### PR DESCRIPTION
Short MM patch that adds a "cck-containers" tag to all USI KIS Kontainers, so that they'll appear in the "Containers" category in the VAB or SPH in game.