### PR TITLE
Increase tanks' LH2 capacity 1.5x to match CryoTanks change

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/FlatRnd_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/FlatRnd_01.cfg
@@ -54,9 +54,9 @@ bulkheadProfiles = size0,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 600;6000;192000;54,66;600;600;600;600;120;120
+		resourceAmounts = 600;6000;192000;54,66;600;600;600;900;120;120
 		initialResourceAmounts = 0;0;0;0,0;0;0;0;0;0;0
-		tankCost = 2400000;24000;2016;55.08;0.48;9600;0;22.05;96;144
+		tankCost = 2400000;24000;2016;55.08;0.48;9600;0;33.075;96;144
 		basePartMass = 0.075
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/FlatRnd_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/FlatRnd_02.cfg
@@ -54,9 +54,9 @@ bulkheadProfiles = size0,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 4500;45000;1440000;405,495;4500;4500;4500;4500;900;900
+		resourceAmounts = 4500;45000;1440000;405,495;4500;4500;4500;6750;900;900
 		initialResourceAmounts = 0;0;0;0,0;0;0;0;0;0;0
-		tankCost = 18000000;180000;15120;413.1;3.6;72000;0;165.375;720;1080
+		tankCost = 18000000;180000;15120;413.1;3.6;72000;0;248.0625;720;1080
 		basePartMass =  0.5625 
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/FlatRnd_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/FlatRnd_03.cfg
@@ -54,9 +54,9 @@ bulkheadProfiles = size0,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 15000;150000;4800000;1350,1650;15000;15000;15000;15000;3000;3000
+		resourceAmounts = 15000;150000;4800000;1350,1650;15000;15000;15000;22500;3000;3000
 		initialResourceAmounts = 0;0;0;0,0;0;0;0;0;0;0
-		tankCost = 60000000;600000;50400;1377;12;240000;0;551.25;2400;3600
+		tankCost = 60000000;600000;50400;1377;12;240000;0;826.875;2400;3600
 		basePartMass =  1.8750 
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/FlatRnd_04.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/FlatRnd_04.cfg
@@ -54,9 +54,9 @@ bulkheadProfiles = size0,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 37500;375000;12000000;3375,4125;37500;37500;37500;37500;7500;7500
+		resourceAmounts = 37500;375000;12000000;3375,4125;37500;37500;37500;56250;7500;7500
 		initialResourceAmounts = 0;0;0;0,0;0;0;0;0;0;0
-		tankCost = 150000000;1500000;126000;3442.5;30;600000;0;1378.125;6000;9000
+		tankCost = 150000000;1500000;126000;3442.5;30;600000;0;2067.1875;6000;9000
 		basePartMass =  4.6875
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/LqdTrussTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/LqdTrussTank.cfg
@@ -55,9 +55,9 @@ bulkheadProfiles = size0,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 14000;140000;4480000;1260,1540;14000;14000;14000;14000;2800;2800
+		resourceAmounts = 14000;140000;4480000;1260,1540;14000;14000;14000;21000;2800;2800
  		initialResourceAmounts = 0;140000;4480000;0,0;0;0;0;0;0;0
- 		tankCost = 56000000;560000;47040;1285.2;11.2;224000;0;514.5;2240;3360
+ 		tankCost = 56000000;560000;47040;1285.2;11.2;224000;0;771.75;2240;3360
 		basePartMass = 1.75
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
@@ -54,9 +54,9 @@ PART:NEEDS[KIS]
 	{
 		name = FSfuelSwitch
 		resourceNames = LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 90,110;1000;1000;1000;1000;200;200
+		resourceAmounts = 90,110;1000;1000;1000;1500;200;200
 		initialResourceAmounts = 0,0;0;0;0;0;0;0
-		tankCost = 91.8;0.8;16000;0;36.75;160;240
+		tankCost = 91.8;0.8;16000;0;55.125;160;240
 		basePartMass = 0.1
 		tankMass = 0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RadialLqdTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RadialLqdTank.cfg
@@ -80,9 +80,9 @@ PART
 	{
 		name = FSfuelSwitch
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 112.5,137.5;1250;1250;1250;1250;250;250
+		resourceAmounts = 112.5,137.5;1250;1250;1250;1875;250;250
 		initialResourceAmounts = 0,0;0;0;0;0;0;0
-		tankCost = 114.75;1;20000;0;45.9375;200;300
+		tankCost = 114.75;1;20000;0;68.90625;200;300
 		basePartMass = 0.15625
 		tankMass = 0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_00.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_00.cfg
@@ -56,9 +56,9 @@ bulkheadProfiles = size0,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 450;4500;144000;40.5,49.5;450;450;450;450;90;90
+		resourceAmounts = 450;4500;144000;40.5,49.5;450;450;450;675;90;90
 		initialResourceAmounts = 0;4500;144000;0,0;0;0;0;0;0;0
-		tankCost = 1800000;18000;1512;41.31;0.36;7200;0;16.5375;72;108
+		tankCost = 1800000;18000;1512;41.31;0.36;7200;0;24.80625;72;108
 		basePartMass = 0.05625
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_01.cfg
@@ -54,9 +54,9 @@ bulkheadProfiles = size0,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 3500;35000;1120000;315,385;3500;3500;3500;3500;700;700
+		resourceAmounts = 3500;35000;1120000;315,385;3500;3500;3500;5250;700;700
  		initialResourceAmounts = 0;35000;1120000;0,0;0;0;0;0;0;0
- 		tankCost = 14000000;140000;11760;321.3;2.8;56000;0;128.625;560;840
+ 		tankCost = 14000000;140000;11760;321.3;2.8;56000;0;192.9375;560;840
 		basePartMass = 0.4375
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_02.cfg
@@ -56,9 +56,9 @@ bulkheadProfiles = size1,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 30000;300000;9600000;2700,3300;30000;30000;30000;30000;6000;6000
+		resourceAmounts = 30000;300000;9600000;2700,3300;30000;30000;30000;45000;6000;6000
 		initialResourceAmounts = 0;300000;9600000;0,0;0;0;0;0;0;0
-		tankCost = 120000000;1200000;100800;2754;24;480000;0;1102.5;4800;7200
+		tankCost = 120000000;1200000;100800;2754;24;480000;0;1653.75;4800;7200
 		basePartMass = 3.75
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_03.cfg
@@ -56,9 +56,9 @@ bulkheadProfiles = size1p5,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 100000;1000000;32000000;9000,11000;100000;100000;100000;100000;20000;20000
+		resourceAmounts = 100000;1000000;32000000;9000,11000;100000;100000;100000;150000;20000;20000
 		initialResourceAmounts = 0;1000000;32000000;0,0;0;0;0;0;0;0
-		tankCost = 400000000;4000000;336000;9180;80;1600000;0;3675;16000;24000
+		tankCost = 400000000;4000000;336000;9180;80;1600000;0;5512.5;16000;24000
 		basePartMass = 12.5
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_04.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_04.cfg
@@ -56,9 +56,9 @@ bulkheadProfiles = size2,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 230000;2300000;73600000;20700,25300;230000;230000;230000;230000;46000;46000
+		resourceAmounts = 230000;2300000;73600000;20700,25300;230000;230000;230000;345000;46000;46000
 		initialResourceAmounts = 0;2300000;73600000;0,0;0;0;0;0;0;0
-		tankCost = 920000000;9200000;772800;21114;184;3680000;0;8452.5;36800;55200
+		tankCost = 920000000;9200000;772800;21114;184;3680000;0;12678.75;36800;55200
 		basePartMass = 28.75
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_06.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_06.cfg
@@ -56,9 +56,9 @@ bulkheadProfiles = size3,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 750000;7500000;240000000;67500,82500;750000;750000;750000;750000;150000;150000
+		resourceAmounts = 750000;7500000;240000000;67500,82500;750000;750000;750000;1125000;150000;150000
 		initialResourceAmounts = 0;7500000;240000000;0,0;0;0;0;0;0;0
-		tankCost = 3000000000;30000000;2520000;68850;600;12000000;0;27562.5;120000;180000
+		tankCost = 3000000000;30000000;2520000;68850;600;12000000;0;41343.75;120000;180000
 		basePartMass = 93.75
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_08.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/RndTank_08.cfg
@@ -56,9 +56,9 @@ bulkheadProfiles = size4,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 1800000;18000000;576000000;162000,198000;1800000;1800000;1800000;1800000;360000;360000
+		resourceAmounts = 1800000;18000000;576000000;162000,198000;1800000;1800000;1800000;2700000;360000;360000
 		initialResourceAmounts = 0;18000000;576000000;0,0;0;0;0;0;0;0
-		tankCost = 7200000000;72000000;6048000;165240;1440;28800000;0;66150;288000;432000
+		tankCost = 7200000000;72000000;6048000;165240;1440;28800000;0;99225;288000;432000
 		basePartMass = 225
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_01.cfg
@@ -54,9 +54,9 @@ bulkheadProfiles = size1,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 2500;25000;800000;225,275;2500;2500;2500;2500;500;500
+		resourceAmounts = 2500;25000;800000;225,275;2500;2500;2500;3750;500;500
 		initialResourceAmounts = 0;0;0;0,0;0;0;0;0;0;0
-		tankCost = 10000000;100000;8400;229.5;2;40000;0;91.875;400;600
+		tankCost = 10000000;100000;8400;229.5;2;40000;0;137.8125;400;600
 		basePartMass = 0.3125
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_02.cfg
@@ -55,9 +55,9 @@ bulkheadProfiles = size2,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 20000;200000;6400000;1800,2200;20000;20000;20000;20000;4000;4000
+		resourceAmounts = 20000;200000;6400000;1800,2200;20000;20000;20000;30000;4000;4000
 		initialResourceAmounts = 0;0;0;0,0;0;0;0;0;0;0
-		tankCost = 80000000;800000;67200;1836;16;320000;0;735;3200;4800
+		tankCost = 80000000;800000;67200;1836;16;320000;0;1102.5;3200;4800
 		basePartMass = 2.5
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_03.cfg
@@ -55,9 +55,9 @@ bulkheadProfiles = size3,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 65000;650000;20800000;5850,7150;65000;65000;65000;65000;13000;13000
+		resourceAmounts = 65000;650000;20800000;5850,7150;65000;65000;65000;97500;13000;13000
 		initialResourceAmounts = 0;0;0;0,0;0;0;0;0;0;0
-		tankCost = 260000000;2600000;218400;5967;52;1040000;0;2388.75;10400;15600
+		tankCost = 260000000;2600000;218400;5967;52;1040000;0;3583.125;10400;15600
 		basePartMass = 8.125
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_04.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/Tank_04.cfg
@@ -55,9 +55,9 @@ bulkheadProfiles = size3,srf
 	{
 		name = FSfuelSwitch
 		resourceNames =Karborundum;XenonGas;ArgonGas;LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 160000;1600000;51200000;14400,17600;160000;160000;160000;160000;32000;32000
+		resourceAmounts = 160000;1600000;51200000;14400,17600;160000;160000;160000;240000;32000;32000
 		initialResourceAmounts = 0;0;0;0,0;0;0;0;0;0;0
-		tankCost = 640000000;6400000;537600;14688;128;2560000;0;5880;25600;38400
+		tankCost = 640000000;6400000;537600;14688;128;2560000;0;8820;25600;38400
 		basePartMass = 20
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false


### PR DESCRIPTION
In the update of CryoTanks for KSP 1.4, LqdHydrogen tank capacities were increased by 50% (i.e. new capacity is 150% of the old) for balancing.  This patch makes the same change in USI tanks' LqdHydrogen fuel switcher configuration.

For reference, see commit ChrisAdderley/CryoTanks@b104b8c6fea76bcc0799e8957492f7d6b54c6f32 and [this forum post](https://forum.kerbalspaceprogram.com/index.php?/topic/106089-142-cryogenic-engines-high-isp-chemical-rockets-april-11/&do=findComment&comment=3347239).

@ChrisAdderley may want to weigh in on this.