### PR TITLE
Adjust MountableSupPack & MountableLqdTank volume to match KIS changes

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
@@ -17,7 +17,7 @@ PART:NEEDS[KIS]
 	TechRequired = advConstruction
 	entryCost = 4160
 
-	cost = 1400
+	cost = 360
 	category = none
 	subcategory = 0
 	title = #LOC_USI_MountableLqdTank_title

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
@@ -80,7 +80,6 @@ PART:NEEDS[KIS]
 	MODULE
 	{
 		name = ModuleKISItemEvaTweaker
-		editorItemsCategory = false
 		carriable = true
 		equipMode = part
 		equipSlot = jetpack

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
@@ -15,16 +15,16 @@ PART:NEEDS[KIS]
 	node_stack_bottom = 0.0, -0.2477, 0.0, 0.0, -1.0, 0.0, 0
 
 	TechRequired = advConstruction
-	entryCost = 4160
+	entryCost = 2288
 
-	cost = 360
+	cost = 198
 	category = none
 	subcategory = 0
 	title = #LOC_USI_MountableLqdTank_title
 	manufacturer = USI - Logistics Division
 	description = #LOC_USI_MountableLqdTank_description
 	attachRules = 1,0,0,1,1
-	mass = 0.125
+	mass = 0.06875
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -54,10 +54,10 @@ PART:NEEDS[KIS]
 	{
 		name = FSfuelSwitch
 		resourceNames = LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 90,110;1000;1000;1000;1500;200;200
+		resourceAmounts = 49.5,60.5;550;550;550;825;110;110
 		initialResourceAmounts = 0,0;0;0;0;0;0;0
-		tankCost = 91.8;0.8;16000;0;55.125;160;240
-		basePartMass = 0.125
+		tankCost = 50.49;0.44;8800;0;30.31875;88;132
+		basePartMass = 0.06875
 		tankMass = 0;0;0;0;0;0;0
 		hasGUI = false
 	}
@@ -80,7 +80,6 @@ PART:NEEDS[KIS]
 	MODULE
 	{
 		name = ModuleKISItemEvaTweaker
-		volumeOverride = 1100
 		editorItemsCategory = false
 		carriable = true
 		equipMode = part

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableSupPak.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableSupPak.cfg
@@ -80,7 +80,6 @@ PART:NEEDS[KIS]
 	MODULE:NEEDS[KIS]
 	{
 		name = ModuleKISItemEvaTweaker
-		editorItemsCategory = false
 		carriable = true
 		equipMode = part
 		equipSlot = jetpack

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableSupPak.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableSupPak.cfg
@@ -15,16 +15,16 @@ PART:NEEDS[KIS]
 	node_stack_bottom = 0.0, -0.2477, 0.0, 0.0, -1.0, 0.0, 0
 
 	TechRequired = advConstruction
-	entryCost = 4160
+	entryCost = 2288
 
-	cost = 1400
+	cost = 770
 	category = none
 	subcategory = 0
 	title = #LOC_USI_MountableSupPack_title
 	manufacturer = USI - Logistics Division
 	description = #LOC_USI_MountableSupPack_description
 	attachRules = 1,0,0,1,1
-	mass = 0.125
+	mass = 0.06875
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -54,10 +54,10 @@ PART:NEEDS[KIS]
 	{
 		name = FSfuelSwitch
 		resourceNames = MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;Polymers;Supplies,Mulch;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt;Silicates;Silicon;RefinedExotics;ColonySupplies;Organics;Rock;MaterialKits,SpecializedParts
-		resourceAmounts = 1000;1000;1000;1000;1000;500,500;1000;1000;1000;960,40;200;1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;850,170
+		resourceAmounts = 550;550;550;550;550;275,275;550;550;550;528,22;110;550;550;550;550;550;550;550;550;550;550;550;550;550;467.5,93.5
 		initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0;0,0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0,0
-		tankCost = 1760;700;300;800;320;150000;2000;14240;8000;2400;4;15800;7000;32000;2000;500;10;300;10;20;250000;15000;500;0.01;7140
-		basePartMass = 0.125
+		tankCost = 968;385;165;440;176;82500;1100;7832;4400;1320;2.2;8690;3850;17600;1100;275;5.5;165;5.5;11;137500;8250;275;0.0055;3927
+		basePartMass = 0.06875
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false
 	}
@@ -80,7 +80,6 @@ PART:NEEDS[KIS]
 	MODULE:NEEDS[KIS]
 	{
 		name = ModuleKISItemEvaTweaker
-		volumeOverride = 1100
 		editorItemsCategory = false
 		carriable = true
 		equipMode = part


### PR DESCRIPTION
KIS updates changed the volume of the SC-62 inventory container from 1000L to 550L (which is more plausible).  The SK-62 and SK-62L kontainer parts are the same size and shape, so I've changed their volume to match.  Mass and cost have been adjusted too, in proportion.

For reference, see ihsoft/KIS#330 for the initial change from 1000L to 280L, and ihsoft/KIS#348 for the later change from 280L to 550L.

(I also removed an obsolete property from the part configs, just because it was right below another line that's no longer needed with this change.)