### PR TITLE
Fix MountableSupPack/MountableLqdTank not appearing on female backpack

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableLqdTank.cfg
@@ -85,10 +85,9 @@ PART:NEEDS[KIS]
 		carriable = true
 		equipMode = part
 		equipSlot = jetpack
-		equipMeshName = jetpack_base01
-		equipBoneName = bn_jetpack01
-		equipPos = (0,0.21,-0.3)
-		equipDir = (280,0,0)
+		equipBoneName = aliasJetpack
+		equipPos = 0.0, 0.21, -0.3
+		equipDir = 280, 0, 0
 		runSpeed = 0.8
 	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableSupPak.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/MountableSupPak.cfg
@@ -85,10 +85,9 @@ PART:NEEDS[KIS]
 		carriable = true
 		equipMode = part
 		equipSlot = jetpack
-		equipMeshName = jetpack_base01
-		equipBoneName = bn_jetpack01
-		equipPos = (0,0.21,-0.3)
-		equipDir = (280,0,0)
+		equipBoneName = aliasJetpack
+		equipPos = 0.0, 0.21, -0.3
+		equipDir = 280, 0, 0
 		runSpeed = 0.8
 	}
 }


### PR DESCRIPTION
Like the SC-62 part from KIS, the SK-62 and SK-62L are meant to appear like a backpack when carried in a kerbal's inventory, but the old way of doing that doesn't work on the female kerbal model.  ihsoft/KIS#269 fixed that for the SC-62 and other KIS parts, and I've made the same change here to the USI parts.