### PR TITLE
Update version file URLs to current repo owner

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/USICore.version
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/USICore.version
@@ -1,10 +1,10 @@
 {
      "NAME":"USI Core",
-	 "URL":"https://raw.githubusercontent.com/BobPalmer/USI_Core/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/USICore.version",
-	 "DOWNLOAD":"https://github.com/BobPalmer/USI_Core/releases",
+	 "URL":"https://raw.githubusercontent.com/UmbraSpaceIndustries/USI_Core/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/USICore.version",
+	 "DOWNLOAD":"https://github.com/UmbraSpaceIndustries/USI_Core/releases",
      "GITHUB":{
-         "USERNAME":"BobPalmer",
-         "REPOSITORY":"UmbraSpaceIndustries",
+         "USERNAME":"UmbraSpaceIndustries",
+         "REPOSITORY":"USI_Core",
          "ALLOW_PRE_RELEASE":false
      },
      "VERSION":{


### PR DESCRIPTION
Hi @BobPalmer,

The URLs in this mod's version file are slightly out of date, they still have the previous repo owner. GitHub helpfully silently redirects them, so they still work, but this can sometimes trrigger GitHub's server-side rate limiting behavior.

Now they're updated to the latest correct values.